### PR TITLE
Do not use jinja variables in name  as it is not supported by migrators

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,8 +2,6 @@ c_compiler:
 - vs2019
 c_stdlib:
 - vs
-c_stdlib_version:
-- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,13 @@
+# Note: we use this variable everywhere except in outputs names as jinja variables in output names are not supported
+# by migrators, see https://github.com/conda-forge/librobometry-feedstock/pull/20#issuecomment-2041618340
 {% set cxx_name = "libgz-sim-yarp-plugins" %}
 {% set plugin_name = "gz-sim-yarp-plugins" %}
 {% set name = "gz-sim-yarp-plugins-split" %}
 {% set version = "0.2.0" %}
 
 package:
-  name: {{ name }}
+  # {{ name }}
+  name: gz-sim-yarp-plugins-split
   version: {{ version }}
 
 source:
@@ -12,10 +15,11 @@ source:
     sha256: 98a6d17f8489723b869b24f4a550da514991028cf4bb29754bf672eee92b759d
 
 build:
-  number: 0
+  number: 1
 
 outputs:
-  - name: {{ cxx_name }}
+  # {{ cxx_name }}
+  - name: libgz-sim-yarp-plugins
     script: build_cxx.sh  # [unix]
     script: bld_cxx.bat  # [win]
     build:
@@ -67,7 +71,8 @@ outputs:
         - if not exist %LIBRARY_BIN%\\gz-sim-yarp-{{ gyp_lib }}.dll exit 1  # [win]
         {% endfor %}
 
-  - name: {{ plugin_name }}
+  # {{ plugin_name }}
+  - name: gz-sim-yarp-plugins
     requirements:
       run:
         - {{ pin_subpackage(cxx_name, exact=True) }}


### PR DESCRIPTION
See discussion in https://github.com/conda-forge/librobometry-feedstock/pull/20#issuecomment-2041618340 . Not doing so results in migrators error (see  https://conda-forge.org/status/migration/libgrpc162_libprotobuf4253 and https://github.com/regro/cf-scripts/actions/runs/8732998278):

~~~
bot error (
[bot CI job](https://github.com/regro/cf-scripts/actions/runs/8732998278)
): main: Traceback (most recent call last):
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/auto_tick.py", line 1253, in _run_migrator
    migrator_uid, pr_json = run(
                            ^^^^
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/auto_tick.py", line 234, in run
    migrator.run_pre_piggyback_migrations(recipe_dir, feedstock_ctx.attrs, **kwargs)
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/migrators/core.py", line 268, in run_pre_piggyback_migrations
    mini_migrator.migrate(recipe_dir, attrs, **kwargs)
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/migrators/cstdlib.py", line 206, in migrate
    sections = _slice_into_output_sections(lines, attrs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/cf-scripts/cf-scripts/cf-scripts/conda_forge_tick/migrators/libboost.py", line 48, in _slice_into_output_sections
    raise RuntimeError("Could not find all output sections in meta.yaml!")
RuntimeError: Could not find all output sections in meta.yaml!
~~~



Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
